### PR TITLE
Use QT_SELECT environment

### DIFF
--- a/src/qconf.cpp
+++ b/src/qconf.cpp
@@ -858,6 +858,7 @@ private:
 	QString genQt4Checks()
 	{
 		QString str =
+		"[ -z \"$QC_QTSELECT\" ] && QC_QTSELECT=\"$QT_SELECT\"\n"
 		"QTSEARCHTTEXT=\"$QC_QTSELECT\"\n"
 		"[ -z \"$QC_QTSELECT\" ] && QTSEARCHTTEXT=\"4 or 5\"\n"
 		"\n"


### PR DESCRIPTION
qtchooser uses QT_SELECT when no -qt command line option. Added
QT_SELECT support to use the same and wanted behaviour.