### PR TITLE
Remove bashism from configure

### DIFF
--- a/configure
+++ b/configure
@@ -173,7 +173,7 @@ fi
 printf "Verifying Qt build environment ... "
 
 if [ -z "$QC_QTSELECT" ]; then
-	QC_QTSELECT="${QT_SELECT/qt/}"
+	QC_QTSELECT="$(echo $QT_SELECT | tr -d "qt")"
 fi
 
 if [ ! -z "$QC_QTSELECT" ]; then


### PR DESCRIPTION
The ${parameter/pattern/string} syntax is supported by bash, but not by other shells, like e.g. dash. So the configure script currently doesn't run on distributions that use dash as the default shell.

Alternatively to this PR you could also change the shebang to /bin/bash , but as this is the only bashism in the script it's not worth changing the shebang.