### PR TITLE
Fix configure on GNU Hurd

### DIFF
--- a/conf/conf4.cpp
+++ b/conf/conf4.cpp
@@ -191,7 +191,9 @@ QStringList qc_splitflags(const QString &flags)
 	bool escaped = false;
 	QChar quote, backslash = QLatin1Char('\\');
 	QString buf;
+#ifdef PATH_MAX
 	buf.reserve(PATH_MAX);
+#endif
 	for (int i=0; i < flags.length(); i++) {
 		if (searchStart && flags[i].isSpace()) {
 			continue;


### PR DESCRIPTION
PATH_MAX is not required by POSIX, and it's not defined on GNU Hurd:
https://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html

In this case the fix is easy, as PATH_MAX is only used for reserving some space in a string, which is just a performance optimization. So it can just be skipped in case PATH_MAX is not defined.